### PR TITLE
Add TLS support to Temporal server connection

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,3 +35,4 @@ provider "temporal" {
 
 - `address` (String) Address of the Temporal server. Of the form `host:port`.
 - `namespace` (String) Namespace to operate in.
+- `tls` (Bool) Whether to use TLS for the Temporal server connection. Defaults to `false`.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.9.0
 	go.temporal.io/api v1.34.0
 	go.temporal.io/sdk v1.27.0
+	google.golang.org/grpc v1.64.0
 	google.golang.org/protobuf v1.34.1
 )
 
@@ -94,7 +95,6 @@ require (
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240521202816-d264139d666e // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240521202816-d264139d666e // indirect
-	google.golang.org/grpc v1.64.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -164,9 +164,9 @@ func (r *namespaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			},
 			"history_archival_state": schema.StringAttribute{
 				MarkdownDescription: "History archival state. Accepted values: `disabled`, `enabled`. History archival must be enabled at the cluster level first to be able to enable it for a namespace.",
-				Optional:    true,
-				Computed:    true,
-				Default:     stringdefault.StaticString("disabled"),
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("disabled"),
 				Validators: []validator.String{
 					validators.StringInSliceValidator{
 						AllowedValues: []string{"enabled", "disabled"},
@@ -376,6 +376,7 @@ func (r *namespaceResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	_, err := r.client.OperatorService().DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
 		NamespaceId: data.ID.ValueString(),
+		Namespace:   data.Name.ValueString(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Error while deleting namespace "+data.Name.ValueString(), err.Error())


### PR DESCRIPTION
Adds support for using TLS when connecting to the temporal server via a new optional `tls` boolean parameter. When testing the changes locally I also discovered an issue with destroying a namespace. Despite what [this code comment](https://github.com/temporalio/api/blob/f44d52e3274b9f6c9ac5a62fd90360f784195bbe/temporal/api/operatorservice/v1/request_response.proto#L72) says, this operation currently fails with an error `Namespace not set on request`. Adding the name to the request resolves it.